### PR TITLE
Linker HLD: Fix typo in relaxtions section

### DIFF
--- a/docs/overlay-hld.adoc
+++ b/docs/overlay-hld.adoc
@@ -849,7 +849,6 @@ addi    t5, t5, 3
 could be relaxed to:
 ```
 addi    t5, zero, 3
-jalr    ra, 0(t6)
 ```
 
 [[Debugger]]


### PR DESCRIPTION
Remove the `jalr` instruction, which is not part of the relaxation.

Addresses #15.