### PR TITLE
Compiler HLD: Improve indirect call example

### DIFF
--- a/docs/overlay-hld.adoc
+++ b/docs/overlay-hld.adoc
@@ -5,7 +5,7 @@
 :counter: image-counter: 0
 :counter: table-counter: 0
 
-= Software Overlay for RISCV - HLD Version 0.6-draft-20210519
+= Software Overlay for RISCV - HLD Version 0.7-draft-20210629
 
 
 :doctype: book
@@ -33,6 +33,9 @@
  |0.6 |May 19,2021| add comments for: a)This design support only rv32 arch
  b)The design does not support overlay ISR's
  |Ofer Shinaar
+ |0.7 |Jun 29,2021| Update indirect call example so that fptr is used for the
+ call
+ |Craig Blackmore
 |=============================================
 {nbsp} +
 {nbsp} +
@@ -694,47 +697,56 @@ void __attribute__((overlaycall)) f2() {
 
 void __attribute__((overlaycall)) (*fptr)();
 
-int main() {
+void set_fptr() {
   fptr = f2;
+}
+
+int main() {
   fptr();
   return 0;
 }
 ```
-`main` compiles and assembles to:
+`main` and `set_fptr` compile and assemble to:
 ```
-00000000 <main>:
-   0:   1141                    c.addi  sp,-16
-   2:   c606                    c.swsp  ra,12(sp)
-   4:   00000537                lui     a0,0x0
-                        4: R_RISCV_OVLPLT_HI20  f2
-   8:   00050513                addi    a0,a0,0 # 0 <main>
-                        8: R_RISCV_OVLPLT_LO12_I        f2
-   c:   000005b7                lui     a1,0x0
-                        c: R_RISCV_HI20 fptr
-  10:   00a5a023                sw      a0,0(a1) # 0 <main>
-                        10: R_RISCV_LO12_S      fptr
-  14:   00000f37                lui     t5,0x0
-                        14: R_RISCV_OVL_HI20    f2
-  18:   000f0f13                addi    t5,t5,0 # 0 <main>
-                        18: R_RISCV_OVL_LO12_I  f2
-  1c:   000f80e7                jalr    ra,0(t6)
-  20:   4501                    c.li    a0,0
-  22:   40b2                    c.lwsp  ra,12(sp)
-  24:   0141                    c.addi  sp,16
-  26:   8082                    c.jr    ra
+00000000 <set_fptr>:
+   0: 00000537            lui a0,0x0
+      0: R_RISCV_OVLPLT_HI20  f2
+   4: 00050513            addi  a0,a0,0 # 0 <set_fptr>
+      4: R_RISCV_OVLPLT_LO12_I  f2
+   8: 000005b7            lui a1,0x0
+      8: R_RISCV_HI20 fptr
+   c: 00a5a023            sw  a0,0(a1) # 0 <set_fptr>
+      c: R_RISCV_LO12_S fptr
+  10: 8082                  c.jr  ra
+
+00000012 <main>:
+  12: 1141                  c.addi  sp,-16
+  14: c606                  c.swsp  ra,12(sp)
+  16: 00000537            lui a0,0x0
+      16: R_RISCV_HI20  fptr
+  1a: 00052503            lw  a0,0(a0) # 0 <set_fptr>
+      1a: R_RISCV_LO12_I  fptr
+  1e: 9502                  c.jalr  a0
+  20: 4501                  c.li  a0,0
+  22: 40b2                  c.lwsp  ra,12(sp)
+  24: 0141                  c.addi  sp,16
+  26: 8082                  c.jr  ra
 ```
 and after linking:
 ```
-204000e4 <main>:
-204000e4:       1141                    c.addi  sp,-16
-204000e6:       c606                    c.swsp  ra,12(sp)
-204000e8:       20400537                lui     a0,0x20400
-204000ec:       34450513                addi    a0,a0,836 # 20400344
-204000f0:       800005b7                lui     a1,0x80000
-204000f4:       10a5a223                sw      a0,260(a1) # 80000104
-204000f8:       00000f37                lui     t5,0x0
-204000fc:       003f0f13                addi    t5,t5,3 # 3
-20400100:       000f80e7                jalr    ra,0(t6)
+204000e4 <set_fptr>:
+204000e4:       20400537                lui     a0,0x20400
+204000e8:       34450513                addi    a0,a0,836 # 20400344
+204000ec:       800005b7                lui     a1,0x80000
+204000f0:       10a5a223                sw      a0,260(a1) # 80000104
+204000f4:       8082                    c.jr    ra
+
+204000f6 <main>:
+204000f6:       1141                    c.addi  sp,-16
+204000f8:       c606                    c.swsp  ra,12(sp)
+204000fa:       80000537                lui     a0,0x80000
+204000fe:       10452503                lw      a0,260(a0) # 80000104
+20400102:       9502                    c.jalr  a0
 20400104:       4501                    c.li    a0,0
 20400106:       40b2                    c.lwsp  ra,12(sp)
 20400108:       0141                    c.addi  sp,16


### PR DESCRIPTION
The example had a direct call because the callee was known at compile time. I've moved the setting of `fptr` to a separate function so that the call is done via the function pointer.