### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ The repostority contains:
 - [RT Engine Implementation](/comrv)
 - [High Level Design](/docs/overlay-hld.adoc)
 - Toolchain github patches:
--- [llvm](https://github.com/westerndigitalcorporation/llvm-project/tree/comrv)
--- binutils (TBD)
+  - [llvm link](https://github.com/westerndigitalcorporation/llvm-project/tree/comrv)
+  - binutils link (TBD)
+  - gdb link (TBD)
 
 The implemantion is based on [“Overlay Software Standard proposal"](https://github.com/fossi-foundation/embedded-sw-overlay/tree/master/docs)
 From FOSSI

--- a/README.md
+++ b/README.md
@@ -5,10 +5,15 @@
 </p>
  
 The repostority contains:
-- Draft proposal for the SW standard [“Overlay Software Standard proposal"](/docs/overlay-software-standard-draft.adoc)
+
 - [RT Engine Implementation](/comrv)
 - [High Level Design](/docs/overlay-hld.adoc)
-- Toolchain github links (future TBD)
+- Toolchain github patches:
+-- [llvm](https://github.com/westerndigitalcorporation/llvm-project/tree/comrv)
+-- binutils (TBD)
+
+The implemantion is based on [“Overlay Software Standard proposal"](https://github.com/fossi-foundation/embedded-sw-overlay/tree/master/docs)
+From FOSSI
 
 Follow `meeting minutes` and status at [tech-overlay task group](https://lists.riscv.org/g/tech-overlay) and/or in [docs](/docs) folder.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The repostority contains:
   - binutils link (TBD)
   - gdb link (TBD)
 
-The implemantion is based on [“Overlay Software Standard proposal"](https://github.com/fossi-foundation/embedded-sw-overlay/tree/master/docs)
+The implementation is based on [“Overlay Software Standard proposal"](https://github.com/fossi-foundation/embedded-sw-overlay/tree/master/docs)
 From FOSSI
 
 Follow `meeting minutes` and status at [tech-overlay task group](https://lists.riscv.org/g/tech-overlay) and/or in [docs](/docs) folder.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
 # RISC-V Software Overlay documents  
 
 The folder includes relevant documents such as high-level-design (HLD), low-level-design, etc.. 
+**_NOTE:_** Overlay software standard was relocated to [FOSSi Foundation github](https://github.com/fossi-foundation/embedded-sw-overlay/tree/master/docs)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,5 @@
 # RISC-V Software Overlay documents  
 
 The folder includes relevant documents such as high-level-design (HLD), low-level-design, etc.. 
+
 **_NOTE:_** Overlay software standard was relocated to [FOSSi Foundation github](https://github.com/fossi-foundation/embedded-sw-overlay/tree/master/docs)


### PR DESCRIPTION
Update readme files to include the changes of relocation of the "Software overlay standard" to FOSSi.